### PR TITLE
Change list of video file extensions that is used to one that is more comprehensive

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict';
 var path = require('path');
-var videoExtensions = require('video-extensions');
+var videoExtensions = require('video-extensions-list');
 var exts = Object.create(null);
 
 videoExtensions.forEach(function (el) {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "mkv"
   ],
   "dependencies": {
-    "video-extensions": "^1.0.0"
+    "video-extensions-list": "*"
   },
   "devDependencies": {
     "ava": "*"


### PR DESCRIPTION
Changed the package that was used for the list of file extensions from ``video-extensions`` to ``video-extensions-list``. The new package has many more video file extensions (488 total) than the one that is currently used (33 total). By changing to a list that has more file types the package will become much more accurate.

[Source](https://fileinfo.com/filetypes/video)